### PR TITLE
Add support for mattermost_url

### DIFF
--- a/gitlab/init.sls
+++ b/gitlab/init.sls
@@ -41,6 +41,18 @@ gitlab-url:
     - require:
       - pkg: gitlab
 
+{% if 'mattermost_url' in gitlab %}
+mattermost-url:
+  file.replace:
+    - name: {{ gitlab.config_file }}
+    - pattern: ^#?\s*mattermost_external_url\s.*$
+    - repl: external_url {{ gitlab.mattermost_url|yaml_dquote }}
+    - append_if_not_found: True
+    - require:
+      - pkg: gitlab
+{% endif %}
+
+
 gitlab-config:
   file.blockreplace:
     - name: {{ gitlab.config_file }}


### PR DESCRIPTION
Configure like 'url', e.g.

```yaml
gitlab:
  url: http://localhost
  mattermost_url:  http://mattermost.example.com/
```