### PR TITLE
fix(mattermost) reconfigure gitlab if mattermost_url is set after install

### DIFF
--- a/gitlab-omnibus/init.sls
+++ b/gitlab-omnibus/init.sls
@@ -80,6 +80,9 @@ mattermost-url:
     - append_if_not_found: True
     - require:
       - pkg: gitlab
+    - onchanges_in:
+      - cmd: gitlab-reconfigure
+
 {% endif %}
 
 {% if 'certificate' in gitlab.pki %}


### PR DESCRIPTION
If mattermost_url is set after first install, gitlab-reconfigure is not
perform.